### PR TITLE
Add testing section to hyperHTML docs

### DIFF
--- a/hyperhtml/documentation/index.html
+++ b/hyperhtml/documentation/index.html
@@ -87,13 +87,16 @@
                   </ul>
                 </li>
                 <li>
-                    <a href="#components">Components</a>
-                    <ul>
-                        <li><a href="#components-0">good ol' style</a></li>
-                        <li><a href="#components-1">modern style</a></li>
-                        <li><a href="#components-2">hyper style</a></li>
-                    </ul>
-                  </li>
+                  <a href="#components">Components</a>
+                  <ul>
+                    <li><a href="#components-0">good ol' style</a></li>
+                    <li><a href="#components-1">modern style</a></li>
+                    <li><a href="#components-2">hyper style</a></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="#testing">Testing</a>
+                </li>
                 <li>
                   <a href="#extras">Extras</a>
                   <ul>
@@ -1278,6 +1281,20 @@
                 The latter attempt is the last resort to find an otherwise hard to reach closed shadowRoot
                 but if you use regularly opened shadows, the <code>shadowRoot</code> node will be automatically available ( suggested ).
               </p>
+            </section>
+            <section id="testing">
+                <h2>Testing</h2><hr>
+                <p>hyperHTML is easy to test in the browser and in NodeJS.
+                  If you're testing in NodeJS you will, however, need a JavaScript implementation of the DOM (<a href="https://github.com/WebReflection/basicHTML">basicHTML</a> or <a href="https://github.com/tmpvar/jsdom">jsdom</a>). 
+                </p>
+                <p>
+                  With NodeJS, if you're using basicHTML or jsdom you can use the same, familiar syntax you would when querying and interacting with the DOM in the browser.
+                </p>
+                <p>Have a look at the links below to see examples of how you <strong>could</strong> test in your target environment. Obviously, you could replace any of the testing libraries with one you prefer.</p>
+                <ul>
+                  <li><a href="https://codepen.io/anon/pen/zdRMQQ?editors=0010">Browser</a></li>
+                  <li><a href="https://runkit.com/embed/jz7xffvshlz0">Node</a></li>
+                </ul>
             </section>
             <section id="extras">
               <h2>Extras</h2><hr>


### PR DESCRIPTION
This PR:
- Adds a brief description about testing
- Shows a sample test suit for testing a simple hyperHTML component or element

It might be a good idea to add a "Testing" section to the docs. The intent is to show that it's testable and it's not required to have a special library to test, other than a JavaScript DOM implementation. This is **not** a distinguishing feature, but I found writing tests to be much easier than with React using Enzyme as there was nothing extra needed other than what one already knows when working with vanilla JS and the DOM.

The test might be too long for a simple example (maybe break it up?) by adding Sinon, but I wanted to show how easy it was to *also* test interactivity.