### PR TITLE
Add Vue input list bindings example.

### DIFF
--- a/hyperhtml/examples/example/vue/bindings-list/fw.js
+++ b/hyperhtml/examples/example/vue/bindings-list/fw.js
@@ -1,0 +1,15 @@
+var app8 = new Vue({
+  el: '#app-8',
+  data: {
+    inputs: ['a', 'b', 'c']
+  }
+})
+
+/*
+<div id="app-8">
+  <div v-for="(inp,index) in inputs">
+      <input v-model="inputs[index]" />
+  </div>
+  {{inputs}}
+</div>
+*/

--- a/hyperhtml/examples/example/vue/bindings-list/hyper.js
+++ b/hyperhtml/examples/example/vue/bindings-list/hyper.js
@@ -1,20 +1,15 @@
 const App = {
   html: hyperHTML.bind(document.querySelector("#app")),
-  wires: [],
-  getWire(i) {
-    return (this.wires[i] || (this.wires[i] = hyperHTML.wire()));
-  },
-  data: {
-    inputs: ["a", "b", "c"]
-  },
+  data: {inputs: ["a", "b", "c"]},
   onInput(event, index) {
     this.data.inputs[index] = event.target.value;
     this.render();
   },
   render() {
-    this.html`${this.data.inputs.map((inp, index) => this.getWire(index)`
-      <input value="${inp}" oninput="${e => this.onInput(e, index)}"><br>
-    `)}${JSON.stringify(this.data.inputs)}`;
+    this.html`${this.data.inputs.map(
+      (inp, index) => hyperHTML.wire(this, ':' + index)`
+      <input value=${inp} oninput=${e => this.onInput(e, index)}><br>`
+    )}${JSON.stringify(this.data.inputs)}`;
   }
 };
 App.render();

--- a/hyperhtml/examples/example/vue/bindings-list/hyper.js
+++ b/hyperhtml/examples/example/vue/bindings-list/hyper.js
@@ -1,0 +1,24 @@
+const App = {
+  html: hyperHTML.bind(document.querySelector("#app")),
+  wires: [],
+  getWire(i) {
+    return (this.wires[i] || (this.wires[i] = hyperHTML.wire()));
+  },
+  data: {
+    inputs: ["a", "b", "c"]
+  },
+  onInput(event, index) {
+    this.data.inputs[index] = event.target.value;
+    this.render();
+  },
+  render() {
+    this.html`${this.data.inputs.map((inp, index) => this.getWire(index)`
+      <input value="${inp}" oninput="${e => this.onInput(e, index)}"><br>
+    `)}${JSON.stringify(this.data.inputs)}`;
+  }
+};
+App.render();
+
+/*
+  <div id="app"></div>
+*/


### PR DESCRIPTION
This example shows a list of inputs.

The template is tricky and the casual user can implement it in a different way with different results: from wrong rendering to runtime errors.

The follow-up is not straightforward from the basic input binding example: indeed there is a getWire using an integer instead of an object, (the wire parameter).

I didn't modify js/index.js, providing a live demo, because the snippets are in `webreflection` context. I am afraid you need to add it yourself.

Fix #11