### PR TITLE
Redirect from /hyperhtml to /hyper.html

### DIFF
--- a/hyperhtml/index.html
+++ b/hyperhtml/index.html
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<!--
+ISC License
+
+Copyright (c) 2018, Andrea Giammarchi, @WebReflection
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+-->
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8"/>
+    <title>Redirecting…</title>
+    <link rel="canonical" href="https://viperhtml.js.org/hyper.html" />
+    <script type="application/javascript">window.location="https://viperhtml.js.org/hyper.html";</script>
+    <meta http-equiv="refresh" content="0; url=https://viperhtml.js.org/hyper.html" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  </head>
+  <body style="display: flex; align-items: center; justify-content: center;">
+    <div>
+      <a href="https://viperhtml.js.org/hyper.html">Click here if you are not redirected.</a>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Previously, if you went to https://viperhtml.js.org/hyperhtml, you’d get a 404 response. This changes it to a redirect to https://viperhtml.js.org/hyper.html.