### PR TITLE
Use viperHTML to statically build the site

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 'use strict';
+/* eslint comma-dangle: ['error', 'always-multiline'] */
 /* eslint sort-keys: ['error', 'asc'] */
 
 module.exports = {
@@ -30,7 +31,10 @@ module.exports = {
   },
   root: true,
   rules: {
-    eqeqeq: 'error',
+    eqeqeq: [
+      'error',
+      'smart',
+    ],
     indent: [
       'error',
       2,

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 # The pre-build script
 before_script:
   - pnpm run lint
+  - chmod u+x ./bin/build
   - chmod u+x ./bin/travis-push-update
 
 # The build script


### PR DESCRIPTION
Since #21 was rejected with the rejection reason given in https://github.com/viperHTML/viperhtml.github.io/pull/21#issuecomment-397205588:
> I appreciate this effort but it would be silly to use anything different from basicHTML or viperHTML to statically pre-generate such content.
>
> This whole project is about template literals to create HTML, using third parts to achieve the same goal would make this project look useless.
>
> Sorry for not accepting this PR and thanks for your understanding.

I went ahead and setup a build system to generate the website content using viperHTML (I’ll probably eventually also add a gulp command [using Browsersync](https://www.browsersync.io/) for easier local testing).

## How to merge
1. Create a `src` branch and make it the new default branch (`*.github.io` user/organisation sites can only be deployed from the `master` branch, not from the `gh‑pages` branch, like project GitHub Pages sites can)
2. Change the base branch of this repository into the newly created `src` branch
3. Merge this into the `src` branch
4. Install [Travis CI](https://github.com/apps/travis-ci) into this repository
5. Make a commit replacing the `GH_TOKEN` environment variable with an actual GitHub deploy token following [this guide](https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml): https://github.com/viperHTML/viperhtml.github.io/blob/a4cf3e3271a3d94651305aa0385fc1c479e94857/.travis.yml#L4 and push the commit to the `src` branch (make sure to use the `api.travis-ci.com` API endpoint to get the encryption keys and not the legacy `api.travis-ci.org` API endpoint, otherwise Travis will fail to decrypt the `GH_TOKEN`).